### PR TITLE
Fixed `getPresenter()` in all core models.

### DIFF
--- a/app/Database/Models/Forum.php
+++ b/app/Database/Models/Forum.php
@@ -52,7 +52,7 @@ class Forum extends Node implements HasPresenter
 	 */
 	public function getPresenterClass()
 	{
-		return \MyBB\Core\Presenters\Forum::class; // TODO: Are we using PHP 5.5 as minimum? If so, this is fine...
+		return 'MyBB\Core\Presenters\Forum';
 	}
 
 	/**

--- a/app/Database/Models/Post.php
+++ b/app/Database/Models/Post.php
@@ -56,7 +56,7 @@ class Post extends Model implements HasPresenter
 	 */
 	public function getPresenterClass()
 	{
-		return \MyBB\Core\Presenters\Post::class; // TODO: Are we using PHP 5.5 as minimum? If so, this is fine...
+		return 'MyBB\Core\Presenters\Post';
 	}
 
 	/**

--- a/app/Database/Models/Topic.php
+++ b/app/Database/Models/Topic.php
@@ -55,7 +55,7 @@ class Topic extends Model implements HasPresenter
 	 */
 	public function getPresenterClass()
 	{
-		return \MyBB\Core\Presenters\Topic::class; // TODO: Are we using PHP 5.5 as minimum? If so, this is fine...
+		return 'MyBB\Core\Presenters\Topic';
 	}
 
 	/**

--- a/app/Database/Models/User.php
+++ b/app/Database/Models/User.php
@@ -57,7 +57,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 	 */
 	public function getPresenterClass()
 	{
-		return \MyBB\Core\Presenters\User::class; // TODO: Are we using PHP 5.5 as minimum? If so, this is fine...
+		return 'MyBB\Core\Presenters\User';
 	}
 
 


### PR DESCRIPTION
Fixes issue #20 by replacing all instances of `::class` in the core models with the fully qualified class names.
