### PR TITLE
Link to the correct topic or forum instead of the action page

### DIFF
--- a/app/Presenters/User.php
+++ b/app/Presenters/User.php
@@ -163,12 +163,13 @@ class User extends BasePresenter
 			case 'topics.delete':
 			case 'topics.restore':
 				$data['topic'] = e($this->topicRepository->find($parameters['id'])->title);
-				$data['url'] = route('topics.show', $parameters['id']);
+				$data['url'] = route('topics.show', [$parameters['slug'], $parameters['id']]);
 				break;
 			case 'topics.create':
 			case 'topics.create.post':
-				$data['forum'] = e($this->forumRepository->find($parameters['forumId'])->title);
-				$data['url'] = route('forums.show', $parameters['forumId']);
+				$forum = $this->forumRepository->find($parameters['forumId']);
+				$data['forum'] = e($forum->title);
+				$data['url'] = route('forums.show', [$forum->slug, $forum->id]);
 				break;
 			case 'search.post':
 			case 'search.results':


### PR DESCRIPTION
The forum/topic name links to the correct forum/topic now instead of eg linking to the reply form.
