### PR TITLE
Fixing forum counters and last_post_id, last_post_user_id updating

### DIFF
--- a/app/Database/Repositories/Decorators/Forum/CachingDecorator.php
+++ b/app/Database/Repositories/Decorators/Forum/CachingDecorator.php
@@ -10,6 +10,8 @@
 namespace MyBB\Core\Database\Repositories\Decorators\Forum;
 
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use MyBB\Core\Database\Models\Forum;
+use MyBB\Core\Database\Models\Post;
 use MyBB\Core\Database\Repositories\IForumRepository;
 
 class CachingDecorator implements IForumRepository
@@ -32,8 +34,7 @@ class CachingDecorator implements IForumRepository
 	 */
 	public function all()
 	{
-		if(($forums = $this->cache->get('forums.all')) == null)
-		{
+		if (($forums = $this->cache->get('forums.all')) == null) {
 			$forums = $this->decoratedRepository->all();
 			$this->cache->forever('forums.all', $forums);
 		}
@@ -72,8 +73,7 @@ class CachingDecorator implements IForumRepository
 	 */
 	public function getIndexTree()
 	{
-		if(($forums = $this->cache->get('forums.index_tree')) == null)
-		{
+		if (($forums = $this->cache->get('forums.index_tree')) == null) {
 			$forums = $this->decoratedRepository->getIndexTree();
 			$this->cache->forever('forums.index_tree', $forums);
 		}
@@ -103,5 +103,18 @@ class CachingDecorator implements IForumRepository
 	public function incrementTopicCount($id = 0)
 	{
 		return $this->decoratedRepository->incrementTopicCount($id);
+	}
+
+	/**
+	 * Update the last post for this forum
+	 *
+	 * @param Forum $forum The forum to update
+	 *
+	 * @return mixed
+	 */
+
+	public function updateLastPost(Forum $forum, Post $post = null)
+	{
+		$this->decoratedRepository->updateLastPost($forum, $post);
 	}
 }

--- a/app/Database/Repositories/Eloquent/ForumRepository.php
+++ b/app/Database/Repositories/Eloquent/ForumRepository.php
@@ -10,6 +10,7 @@
 namespace MyBB\Core\Database\Repositories\Eloquent;
 
 use MyBB\Core\Database\Models\Forum;
+use MyBB\Core\Database\Models\Post;
 use MyBB\Core\Database\Repositories\IForumRepository;
 
 class ForumRepository implements IForumRepository
@@ -74,11 +75,11 @@ class ForumRepository implements IForumRepository
 	{
 		// TODO: doesn't load relations for children, probably need to add children.lastPost etc? (@euan)
 		return $this->forumModel->where('parent_id', '=', null)->with([
-			                                                              'children',
-			                                                              'lastPost',
-			                                                              'lastPost.topic',
-			                                                              'lastPostAuthor'
-		                                                              ])->get();
+			'children',
+			'lastPost',
+			'lastPost.topic',
+			'lastPostAuthor'
+		])->get();
 	}
 
 	/**
@@ -92,8 +93,7 @@ class ForumRepository implements IForumRepository
 	{
 		$forum = $this->find($id);
 
-		if($forum)
-		{
+		if ($forum) {
 			$forum->increment('num_posts');
 		}
 
@@ -111,10 +111,31 @@ class ForumRepository implements IForumRepository
 	{
 		$forum = $this->find($id);
 
-		if($forum)
-		{
+		if ($forum) {
 			$forum->increment('num_topics');
 		}
+
+		return $forum;
+	}
+
+	/**
+	 * Update the last post for this forum
+	 *
+	 * @param Forum $forum The forum to update
+	 *
+	 * @return mixed
+	 */
+
+	public function updateLastPost(Forum $forum, Post $post = null)
+	{
+		if ($post === null) {
+			$post = $forum->topics->sortByDesc('last_post_id')->first()->lastPost;
+		}
+
+		$forum->update([
+			'last_post_id' => $post->id,
+			'last_post_user_id' => $post->user_id
+		]);
 
 		return $forum;
 	}

--- a/app/Database/Repositories/Eloquent/TopicRepository.php
+++ b/app/Database/Repositories/Eloquent/TopicRepository.php
@@ -13,8 +13,10 @@ use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\Str;
 use MyBB\Core\Database\Models\Forum;
+use MyBB\Core\Database\Models\Post;
 use MyBB\Core\Database\Models\Topic;
 use MyBB\Core\Database\Models\User;
+use MyBB\Core\Database\Repositories\IForumRepository;
 use MyBB\Core\Database\Repositories\IPostRepository;
 use MyBB\Core\Database\Repositories\ITopicRepository;
 use MyBB\Settings\Store;
@@ -47,6 +49,9 @@ class TopicRepository implements ITopicRepository
 	/** @var Store $settings */
 	private $settings;
 
+	/** @var IForumRepository */
+	private $forumRepository;
+
 	/**
 	 * @param Topic           $topicModel     The model to use for threads.
 	 * @param Guard           $guard          Laravel guard instance, used to get user ID.
@@ -61,7 +66,8 @@ class TopicRepository implements ITopicRepository
 		IPostRepository $postRepository,
 		Str $stringUtils,
 		DatabaseManager $dbManager,
-		Store $settings
+		Store $settings,
+		IForumRepository $forumRepository
 	) // TODO: Inject permissions container? So we can check thread permissions before querying?
 	{
 		$this->topicModel = $topicModel;
@@ -70,6 +76,7 @@ class TopicRepository implements ITopicRepository
 		$this->stringUtils = $stringUtils;
 		$this->dbManager = $dbManager;
 		$this->settings = $settings;
+		$this->forumRepository = $forumRepository;
 	}
 
 	/**
@@ -130,10 +137,10 @@ class TopicRepository implements ITopicRepository
 	public function getNewest($num = 20)
 	{
 		return $this->topicModel->orderBy('last_post_id', 'desc')->with([
-			                                                                'lastPost',
-			                                                                'forum',
-			                                                                'lastPost.author'
-		                                                                ])->take($num)->get();
+			'lastPost',
+			'forum',
+			'lastPost.author'
+		])->take($num)->get();
 	}
 
 	/**
@@ -148,8 +155,7 @@ class TopicRepository implements ITopicRepository
 	public function allForForum(Forum $forum, $orderBy = 'posts.created_at', $orderDir = 'desc')
 	{
 		// Build the correct order_by column - nice versions may be submitted
-		switch($orderBy)
-		{
+		switch ($orderBy) {
 			case 'replies':
 				$orderBy = 'num_posts';
 				break;
@@ -165,8 +171,8 @@ class TopicRepository implements ITopicRepository
 		$topicsPerPage = $this->settings->get('user.topics_per_page', 20);
 
 		return $this->topicModel->withTrashed()->with(['author', 'lastPost', 'lastPost.author'])
-		                        ->leftJoin('posts', 'last_post_id', '=', 'posts.id')->where('forum_id', '=', $forum->id)
-		                        ->orderBy($orderBy, $orderDir)->paginate($topicsPerPage, ['topics.*']);
+			->leftJoin('posts', 'last_post_id', '=', 'posts.id')->where('forum_id', '=', $forum->id)
+			->orderBy($orderBy, $orderDir)->paginate($topicsPerPage, ['topics.*']);
 	}
 
 	/**
@@ -179,42 +185,38 @@ class TopicRepository implements ITopicRepository
 	public function create(array $details = [])
 	{
 		$details = array_merge([
-			                       'title' => '',
-			                       'forum_id' => 0,
-			                       'user_id' => $this->guard->user()->id,
-			                       'username' => null,
-			                       'first_post_id' => 0,
-			                       'last_post_id' => 0,
-			                       'views' => 0,
-			                       'num_posts' => 0,
-			                       'content' => '',
-		                       ], $details);
+			'title' => '',
+			'forum_id' => 0,
+			'user_id' => $this->guard->user()->id,
+			'username' => null,
+			'first_post_id' => 0,
+			'last_post_id' => 0,
+			'views' => 0,
+			'num_posts' => 0,
+			'content' => '',
+		], $details);
 
 		$details['slug'] = $this->createSlugForTitle($details['title']);
 
-		if($details['user_id'] > 0)
-		{
+		if ($details['user_id'] > 0) {
 			$details['username'] = User::find($details['user_id'])->name; // TODO: Use User Repository!
-		} else
-		{
+		} else {
 			$details['user_id'] = null;
-			if($details['username'] == trans('general.guest'))
-			{
+			if ($details['username'] == trans('general.guest')) {
 				$details['username'] = null;
 			}
 		}
 
 		$topic = null;
 
-		$this->dbManager->transaction(function () use ($details, &$topic)
-		{
+		$this->dbManager->transaction(function () use ($details, &$topic) {
 			$topic = $this->topicModel->create([
-				                                   'title' => $details['title'],
-				                                   'slug' => $details['slug'],
-				                                   'forum_id' => $details['forum_id'],
-				                                   'user_id' => $details['user_id'],
-				                                   'username' => $details['username'],
-			                                   ]);
+				'title' => $details['title'],
+				'slug' => $details['slug'],
+				'forum_id' => $details['forum_id'],
+				'user_id' => $details['user_id'],
+				'username' => $details['username'],
+			]);
 
 			$firstPost = $this->postRepository->addPostToTopic($topic, [
 				'content' => $details['content'],
@@ -222,16 +224,15 @@ class TopicRepository implements ITopicRepository
 			]);
 
 			$topic->update([
-				               'first_post_id' => $firstPost->id,
-				               'last_post_id' => $firstPost->id,
-				               'num_posts' => 1,
-			               ]);
+				'first_post_id' => $firstPost->id,
+				'last_post_id' => $firstPost->id,
+				'num_posts' => 1,
+			]);
 		});
 
 		$topic->forum->increment('num_topics');
 
-		if($topic->user_id > 0)
-		{
+		if ($topic->user_id > 0) {
 			$topic->author->increment('num_topics');
 		}
 
@@ -247,7 +248,7 @@ class TopicRepository implements ITopicRepository
 	 */
 	private function createSlugForTitle($title = '')
 	{
-		$title = (string) $title;
+		$title = (string)$title;
 		$sluggedTitle = $this->stringUtils->slug($title, '-');
 
 		return $sluggedTitle;
@@ -279,28 +280,23 @@ class TopicRepository implements ITopicRepository
 
 	public function deleteTopic(Topic $topic)
 	{
-		if($topic['deleted_at'] == null)
-		{
+		if ($topic['deleted_at'] == null) {
 			$topic->forum->decrement('num_topics');
 			$topic->forum->decrement('num_posts', $topic->num_posts);
 
 			$topic->author->decrement('num_topics');
 
-			return $topic->delete();
-		} else
-		{
-			// TODO: correctly update the lastpost here
+			$success = $topic->delete();
 
-			$topic->forum->where('last_post_id', '=', $topic->last_post_id)->update([
-				'last_post_id' => null,
-				'last_post_user_id' => null
-			]);
+			if ($success) {
+				if ($topic->last_post_id == $topic->forum->last_post_id) {
+					$this->forumRepository->updateLastPost($topic->forum);
+				}
+			}
 
-			$topic->update([
-				               'first_post_id' => null,
-				               'last_post_id' => null
-			               ]);
-			$this->postRepository->deletePostsForTopic($topic, true);
+			return $success;
+		} else {
+			$topic->posts->forceDelete();
 
 			return $topic->forceDelete();
 		}
@@ -321,7 +317,15 @@ class TopicRepository implements ITopicRepository
 
 		$topic->author->increment('num_topics');
 
-		return $topic->restore();
+		$success = $topic->restore();
+
+		if ($success) {
+			if ($topic->last_post_id > $topic->forum->last_post_id) {
+				$this->forumRepository->updateLastPost($topic->forum, $topic->lastPost);
+			}
+		}
+
+		return $success;
 	}
 
 	/**
@@ -335,6 +339,27 @@ class TopicRepository implements ITopicRepository
 	public function findBySlugAndId($slug = '', $id = 0)
 	{
 		return $this->topicModel->withTrashed()->with(['author'])->where('slug', '=', $slug)->where('id', '=', $id)
-		                        ->first();
+			->first();
+	}
+
+	/**
+	 * Update the last post of the topic
+	 *
+	 * @param Topic $topic The topic to update
+	 *
+	 * @return mixed
+	 */
+
+	public function updateLastPost(Topic $topic, Post $post = null)
+	{
+		if ($post === null) {
+			$post = $topic->posts->sortByDesc('id')->first();
+		}
+
+		$topic->update([
+			'last_post_id' => $post->id
+		]);
+
+		return $topic;
 	}
 }

--- a/app/Database/Repositories/IForumRepository.php
+++ b/app/Database/Repositories/IForumRepository.php
@@ -9,6 +9,9 @@
 
 namespace MyBB\Core\Database\Repositories;
 
+use MyBB\Core\Database\Models\Forum;
+use MyBB\Core\Database\Models\Post;
+
 interface IForumRepository
 {
 	/**
@@ -60,4 +63,14 @@ interface IForumRepository
 	 * @return mixed
 	 */
 	public function incrementTopicCount($id = 0);
+
+	/**
+	 * Update the last post for this forum
+	 *
+	 * @param Forum $forum The forum to update
+	 *
+	 * @return mixed
+	 */
+
+	public function updateLastPost(Forum $forum, Post $post = null);
 }

--- a/app/Database/Repositories/ITopicRepository.php
+++ b/app/Database/Repositories/ITopicRepository.php
@@ -10,6 +10,7 @@
 namespace MyBB\Core\Database\Repositories;
 
 use MyBB\Core\Database\Models\Forum;
+use MyBB\Core\Database\Models\Post;
 use MyBB\Core\Database\Models\Topic;
 
 interface ITopicRepository
@@ -82,4 +83,14 @@ interface ITopicRepository
 	 * @return mixed
 	 */
 	public function create(array $details = []);
+
+	/**
+	 * Update the last post of the topic
+	 *
+	 * @param Topic $topic The topic to update
+	 *
+	 * @return mixed
+	 */
+
+	public function updateLastPost(Topic $topic, Post $post = null);
 }

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -60,8 +60,7 @@ class TopicController extends Controller
 	{
 		$topic = $this->topicRepository->find($id);
 
-		if(!$topic)
-		{
+		if (!$topic) {
 			throw new NotFoundHttpException(trans('errors.topic_not_found'));
 		}
 
@@ -79,8 +78,7 @@ class TopicController extends Controller
 		$topic = $this->topicRepository->find($id);
 		$post = $this->postRepository->find($postId);
 
-		if(!$post || !$topic || $post['topic_id'] != $topic['id'])
-		{
+		if (!$post || !$topic || $post['topic_id'] != $topic['id']) {
 			throw new NotFoundHttpException(trans('errors.topic_not_found'));
 		}
 
@@ -88,11 +86,9 @@ class TopicController extends Controller
 
 		$numPost = $this->postRepository->getNumForPost($post, true);
 
-		if(ceil($numPost / $postsPerPage) == 1)
-		{
+		if (ceil($numPost / $postsPerPage) == 1) {
 			return redirect()->route('topics.show', ['slug' => $topic->slug, 'id' => $topic->id, '#post-' . $post->id]);
-		} else
-		{
+		} else {
 			return redirect()->route('topics.show', [
 				'slug' => $topic->slug,
 				'id' => $topic->id,
@@ -106,8 +102,7 @@ class TopicController extends Controller
 	{
 		$topic = $this->topicRepository->find($id);
 
-		if(!$topic)
-		{
+		if (!$topic) {
 			throw new NotFoundHttpException(trans('errors.topic_not_found'));
 		}
 
@@ -115,12 +110,10 @@ class TopicController extends Controller
 
 		$numPost = $this->postRepository->getNumForPost($topic->lastPost, true);
 
-		if(ceil($numPost / $postsPerPage) == 1)
-		{
+		if (ceil($numPost / $postsPerPage) == 1) {
 			return redirect()->route('topics.show',
-			                         ['slug' => $topic->slug, 'id' => $topic->id, '#post-' . $topic->last_post_id]);
-		} else
-		{
+				['slug' => $topic->slug, 'id' => $topic->id, '#post-' . $topic->last_post_id]);
+		} else {
 			return redirect()->route('topics.show', [
 				'slug' => $topic->slug,
 				'id' => $topic->id,
@@ -134,8 +127,7 @@ class TopicController extends Controller
 	{
 		$topic = $this->topicRepository->find($id);
 
-		if(!$topic)
-		{
+		if (!$topic) {
 			throw new NotFoundHttpException(trans('errors.topic_not_found'));
 		}
 
@@ -149,8 +141,7 @@ class TopicController extends Controller
 		/** @var Topic $topic */
 		$topic = $this->topicRepository->find($id);
 
-		if(!$topic)
-		{
+		if (!$topic) {
 			throw new NotFoundHttpException(trans('errors.topic_not_found'));
 		}
 
@@ -159,8 +150,7 @@ class TopicController extends Controller
 			'username' => $replyRequest->input('username'),
 		]);
 
-		if($post)
-		{
+		if ($post) {
 			return redirect()->route('topics.last', ['slug' => $topic->slug, 'id' => $topic->id]);
 		}
 
@@ -172,8 +162,7 @@ class TopicController extends Controller
 		$topic = $this->topicRepository->find($id);
 		$post = $this->postRepository->find($postId);
 
-		if(!$post || !$topic || $post['topic_id'] != $topic['id'])
-		{
+		if (!$post || !$topic || $post['topic_id'] != $topic['id']) {
 			throw new NotFoundHttpException(trans('errors.post_not_found'));
 		}
 
@@ -187,25 +176,22 @@ class TopicController extends Controller
 		$topic = $this->topicRepository->find($id);
 		$post = $this->postRepository->find($postId);
 
-		if(!$post || !$topic || $post['topic_id'] != $topic['id'])
-		{
+		if (!$post || !$topic || $post['topic_id'] != $topic['id']) {
 			throw new NotFoundHttpException(trans('errors.post_not_found'));
 		}
 
 		$post = $this->postRepository->editPost($post, [
 			'content' => $replyRequest->input('content'),
 		]);
-		if($post['id'] == $topic['first_post_id'])
-		{
+		if ($post['id'] == $topic['first_post_id']) {
 			$topic = $this->topicRepository->editTopic($topic, [
 				'title' => $replyRequest->input('title'),
 			]);
 		}
 
-		if($post)
-		{
+		if ($post) {
 			return redirect()->route('topics.showPost',
-			                         ['slug' => $topic->slug, 'id' => $topic->id, 'postId' => $post->id]);
+				['slug' => $topic->slug, 'id' => $topic->id, 'postId' => $post->id]);
 		}
 
 		return new \Exception('Error editing post'); // TODO: Redirect back with error...
@@ -215,8 +201,7 @@ class TopicController extends Controller
 	{
 		$forum = $this->forumRepository->find($forumId);
 
-		if(!$forum)
-		{
+		if (!$forum) {
 			throw new NotFoundHttpException(trans('errors.forum_not_found'));
 		}
 
@@ -228,18 +213,17 @@ class TopicController extends Controller
 	public function postCreate($forumId = 0, CreateRequest $createRequest)
 	{
 		$topic = $this->topicRepository->create([
-			                                        'title' => $createRequest->input('title'),
-			                                        'forum_id' => $createRequest->input('forum_id'),
-			                                        'first_post_id' => 0,
-			                                        'last_post_id' => 0,
-			                                        'views' => 0,
-			                                        'num_posts' => 0,
-			                                        'content' => $createRequest->input('content'),
-			                                        'username' => $createRequest->input('username'),
-		                                        ]);
+			'title' => $createRequest->input('title'),
+			'forum_id' => $createRequest->input('forum_id'),
+			'first_post_id' => 0,
+			'last_post_id' => 0,
+			'views' => 0,
+			'num_posts' => 0,
+			'content' => $createRequest->input('content'),
+			'username' => $createRequest->input('username'),
+		]);
 
-		if($topic)
-		{
+		if ($topic) {
 			return redirect()->route('topics.show', ['slug' => $topic->slug, 'id' => $topic->id]);
 		}
 
@@ -251,26 +235,20 @@ class TopicController extends Controller
 		$topic = $this->topicRepository->find($id);
 		$post = $this->postRepository->find($postId);
 
-		if(!$post || !$topic || $post['topic_id'] != $topic['id'])
-		{
+		if (!$post || !$topic || $post['topic_id'] != $topic['id']) {
 			throw new NotFoundHttpException(trans('errors.post_not_found'));
 		}
 
 
-		if($post['id'] == $topic['first_post_id'])
-		{
+		if ($post['id'] == $topic['first_post_id']) {
 			$this->topicRepository->deleteTopic($topic);
 
 			return redirect()->route('forums.show', ['slug' => $topic->forum['slug'], 'id' => $topic->forum['id']]);
-		} else
-		{
+		} else {
 			$this->postRepository->deletePost($post);
-			$topic = $this->postRepository->updateLastPost($topic);
 
 			return redirect()->route('topics.show', ['slug' => $topic['slug'], 'id' => $topic['id']]);
 		}
-
-		return new \Exception(trans('errors.error_deleting_topic')); // TODO: Redirect back with error...
 	}
 
 	public function restore($slug = '', $id = 0, $postId = 0)
@@ -278,23 +256,18 @@ class TopicController extends Controller
 		$topic = $this->topicRepository->find($id);
 		$post = $this->postRepository->find($postId);
 
-		if(!$post || !$topic || $post['topic_id'] != $topic['id'] || !$post['deleted_at'] && !$topic['deleted_at'])
-		{
+		if (!$post || !$topic || $post['topic_id'] != $topic['id'] || !$post['deleted_at'] && !$topic['deleted_at']) {
 			throw new NotFoundHttpException(trans('errors.post_not_found'));
 		}
 
-		if($post['id'] == $topic['first_post_id'])
-		{
+		if ($post['id'] == $topic['first_post_id']) {
 			$this->topicRepository->restoreTopic($topic);
-		} else
-		{
+		} else {
 			$this->postRepository->restorePost($post);
-			$topic = $this->postRepository->updateLastPost($topic);
 		}
-		if($topic)
-		{
+		if ($topic) {
 			return redirect()->route('topics.showPost',
-			                         ['slug' => $topic->slug, 'id' => $topic->id, 'postId' => $post->id]);
+				['slug' => $topic->slug, 'id' => $topic->id, 'postId' => $post->id]);
 		}
 
 		return new \Exception(trans('errors.error_deleting_topic')); // TODO: Redirect back with error...

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -18,11 +18,11 @@ class PostsTableSeeder extends Seeder
 		];
 
 		$id = DB::table('posts')->insertGetId($post);
+		DB::table('topics')->where('slug', 'my-topic')->increment('num_posts');
 		DB::table('topics')->where('slug', 'my-topic')->update([
-			                                                       'last_post_id' => $id,
-			                                                       'first_post_id' => $id,
-			                                                       'num_posts' => 1
-		                                                       ]);
+			'last_post_id' => $id,
+			'first_post_id' => $id,
+		]);
 
 		DB::table('forums')->where('slug', 'my-forum')->increment('num_posts');
 		DB::table('forums')->where('slug', 'my-forum')->update([

--- a/database/seeds/TopicsTableSeeder.php
+++ b/database/seeds/TopicsTableSeeder.php
@@ -19,7 +19,7 @@ class TopicsTableSeeder extends Seeder
 			'views' => 0,
 			'created_at' => new \DateTime(),
 			'updated_at' => new \DateTime(),
-			'num_posts' => 1,
+			'num_posts' => 0,
 		];
 
 		DB::table('topics')->insert($topic);


### PR DESCRIPTION
Note: last post isn't updated when restoring a post/topic atm and sometimes not properly when deleting them. Going to change that later.

Also:

> About soft deleting: atm soft deleting a topic/post updates the counters but no foreign keys (last post for example). Those are only updated on hard delete. IMHO that should be changed. Soft Deleted posts shouldn't be considered in any overview/counter as "last/first/newest whatever". They should only be displayed after you entered the forum/topic.
