### PR TITLE
Add some standards and best practices to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,9 @@ In addition to the PSR-2 standard, we have other standards and best practices th
 - Properties on an object SHOULD have `protected` or `private` visibility.
 
 ```php
+/**
+ * @property string magic
+ */
 class Foo
 {
     /**
@@ -64,11 +67,20 @@ class Foo
     {
         $this->bar = $bar;
     }
+    
+    /**
+     * @param string $name
+     */
+    public function __get($name)
+    {
+        return 'magic';
+    }
 }
 ```
 
 - Methods with a return value and/or arguments MUST have a document block.
 - Object properties MUST have a document block with `@var` tag denoting their type.
+- Magic properties on an object MUST be declared in a doc block at the top of the class using the `@property` tag.
 - Method arguments that are required MUST NOT have a default value.
 
 Should your pull request not follow these standards, you will be requested to reformat your code to suit.


### PR DESCRIPTION
Proposing we add the additional standards and best practices to our CONTRIBUTING file. The reason behind them is so that we are all coding consistently which in turn makes it easier to develop the codebase as a whole.

Some of them are also conventions of other PHP projects so it brings more inline with the community as well, which I always think is a good thing :)

Let me know what you think, happy to explain the reasoning behind each of them individually. Would be great to see this merged!
