### PR TITLE
Rename Command to AbstractCommand

### DIFF
--- a/app/Commands/Command.php
+++ b/app/Commands/Command.php
@@ -1,6 +1,6 @@
 <?php namespace MyBB\Core\Commands;
 
-abstract class Command
+abstract class AbstractCommand
 {
 
 	//


### PR DESCRIPTION
Our CONTRIBUTING file states that abstract classes MUST be prefixed with `Abstract`. L5 comes bundled with a bunch of abstract classes that do not conform to this convention.

Suggest we (read: I) rename them accordingly, starting with this one.
