### PR TITLE
Fix migrations and a wrong function call

### DIFF
--- a/database/migrations/2015_03_23_213855_create_profile_field_group_table.php
+++ b/database/migrations/2015_03_23_213855_create_profile_field_group_table.php
@@ -3,7 +3,8 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateProfileFieldGroupTable extends Migration {
+class CreateProfileFieldGroupTable extends Migration
+{
 
 	/**
 	 * Run the migrations.
@@ -33,7 +34,7 @@ class CreateProfileFieldGroupTable extends Migration {
 	public function down()
 	{
 		Schema::table('profile_fields', function (Blueprint $table) {
-//			$table->dropForeign(['profile_field_group_id']);
+			$table->dropForeign(['profile_field_group_id']);
 		});
 		Schema::drop('profile_field_groups');
 	}

--- a/database/migrations/2015_03_29_145952_add_num_likes_to_users_table.php
+++ b/database/migrations/2015_03_29_145952_add_num_likes_to_users_table.php
@@ -15,7 +15,7 @@ class AddNumLikesToUsersTable extends Migration
         Schema::table(
             'users',
             function (Blueprint $table) {
-                $table->unsignedInteger('num_likes_made');
+                $table->unsignedInteger('num_likes_made')->default(0);
             }
         );
     }

--- a/database/migrations/2015_03_29_145958_add_num_likes_to_posts_table.php
+++ b/database/migrations/2015_03_29_145958_add_num_likes_to_posts_table.php
@@ -13,7 +13,7 @@ class AddNumLikesToPostsTable extends Migration
     public function up()
     {
         Schema::table('posts', function(Blueprint $table) {
-            $table->unsignedInteger('num_likes');
+            $table->unsignedInteger('num_likes')->default(0);
         });
     }
 

--- a/resources/views/forum/all.twig
+++ b/resources/views/forum/all.twig
@@ -28,7 +28,7 @@
 						<div class="forum__topic forum__topic--latest">
 							<a href="" class="avatar-profile-link" title="Go to {{ forum.lastPostAuthor.name }}'s profile"><img src="{{ forum.lastPostAuthor.avatar }}" class="avatar" /></a>
 							<h4 class="forum__topic__title"><a href="{{ url_route("topics.show", [forum.lastPost.topic.slug, forum.lastPost.topic.id]) }}">{{ forum.lastPost.topic.title }}</a></h4>
-							<p class="forum__topic__post">{{ post_date_link(url_route("topics.last", [forum.lastPost.topic.slug, forum.lastPost.topic.id]), forum.lastPost.created_at) }} {{ trans('general.by') }} {{ generate_profile_link(forum.lastPostAuthor) }}</p>
+							<p class="forum__topic__post">{{ post_date_link(url_route("topics.last", [forum.lastPost.topic.slug, forum.lastPost.topic.id]), forum.lastPost.created_at) }} {{ trans('general.by') }} {{ render_profile_link(forum.lastPostAuthor) }}</p>
 						</div>
 					</div>
 				{% endfor %}


### PR DESCRIPTION
@euantorano @wpillar 

Not sure whether it was intentional that the `num_likes` columns didn't have a default value but it broke the Seeders and IIRC you hadn't updated the create functions (reply/signup) and this was the easiest way to fix it (and seems logical to me).

Note that running the seeders twice will still throw errors as it tries to truncate the tables without updating foreign keys first. Not yet sure whether we want to support that?
