### PR TITLE
Fix missing initialization on CheckAccess middleware

### DIFF
--- a/app/Http/Middleware/CheckAccess.php
+++ b/app/Http/Middleware/CheckAccess.php
@@ -3,6 +3,7 @@
 use Closure;
 use MyBB\Auth\Contracts\Guard;
 use MyBB\Core\Permissions\PermissionChecker;
+use MyBB\Settings\Store;
 
 class CheckAccess
 {
@@ -12,14 +13,19 @@ class CheckAccess
 	/** @var  PermissionChecker */
 	private $permissionChecker;
 
+	/** @var Store */
+	private $settings;
+
 	/**
 	 * @param Guard             $auth
 	 * @param PermissionChecker $permissionChecker
+	 * @param Store             $settings
 	 */
-	public function __construct(Guard $auth, PermissionChecker $permissionChecker)
+	public function __construct(Guard $auth, PermissionChecker $permissionChecker, Store $settings)
 	{
 		$this->auth = $auth;
 		$this->permissionChecker = $permissionChecker;
+		$this->settings = $settings;
 	}
 
 	/**
@@ -36,8 +42,20 @@ class CheckAccess
 			return $next($request);
 		}
 
+		app()->setLocale($this->settings->get('user.language', 'en'));
+
+		$langDir = [
+			'left' => 'left',
+			'right' => 'right'
+		];
+
+		if (trans('general.direction') == 'rtl') {
+			$langDir['left'] = 'right';
+			$langDir['right'] = 'left';
+		}
+
 		// TODO: The acp should probably create another view
-		return view('errors.no_permission');
+		return view('errors.no_permission')->with('auth_user', $this->auth->user())->with('langDir', $langDir);
 	}
 
 	/**


### PR DESCRIPTION
As we set the language and some other variables in the `Controller::__construct` method which isn't run when a middleware returns a redirect/view some things are missing (wrong language, missing avatar etc). This PR fixes this by copying the code, however we should look whether we can add a `init` function somewhere which is run as soon as possible.
