### PR TITLE
Fixes #86 Bio not usable

### DIFF
--- a/resources/views/partials/form/field_textarea.twig
+++ b/resources/views/partials/form/field_textarea.twig
@@ -1,1 +1,1 @@
-<textarea name="{{ name }}" rows="{{ rows }}" cols="{{ cols }}" {{ is_required ? 'required' }} {{ min_length is defined ? 'minlength=' ~ min_length }} {{ max_length is defined ? 'maxlength=' ~ max_length }}>{{ value }}</textarea>
+<textarea name="{{ name }}" rows="{{ rows }}" cols="{{ cols }}" {{ is_required ? 'required' }} {{ min_length is defined and min_length > 0 ? 'minlength=' ~ min_length }} {{ max_length is defined and max_length > min_length ? 'maxlength=' ~ max_length }}>{{ value }}</textarea>


### PR DESCRIPTION
#86

It doesn't make sense to set `minlength` to `0` and `maxlength` to something less than `minlength`. With the current code both is set to `0` if nothing is specified which makes the field completly unusable.
