### PR TITLE
Code cleanup

### DIFF
--- a/app/Moderation/ModerationServiceProvider.php
+++ b/app/Moderation/ModerationServiceProvider.php
@@ -10,7 +10,13 @@ namespace MyBB\Core\Moderation;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
-use MyBB\Core\Moderation\Moderations\Approve;
+use MyBB\Core\Database\Repositories\Eloquent\ModerationLogRepository;
+use MyBB\Core\Database\Repositories\Eloquent\ModerationLogSubjectRepository;
+use MyBB\Core\Database\Repositories\ModerationLogRepositoryInterface;
+use MyBB\Core\Database\Repositories\ModerationLogSubjectRepositoryInterface;
+use MyBB\Core\Moderation\Logger\DatabaseLogger;
+use MyBB\Core\Moderation\Logger\ModerationLoggerInterface;
+use MyBB\Core\Moderation\Moderations;
 
 class ModerationServiceProvider extends ServiceProvider
 {
@@ -21,31 +27,31 @@ class ModerationServiceProvider extends ServiceProvider
 	 */
 	public function register()
 	{
-		$this->app->singleton('MyBB\Core\Moderation\ModerationRegistry', function (Application $app) {
+		$this->app->singleton(ModerationRegistry::class, function (Application $app) {
 			return new ModerationRegistry([
-				$app->make('MyBB\Core\Moderation\Moderations\Approve'),
-				$app->make('MyBB\Core\Moderation\Moderations\MovePost'),
-				$app->make('MyBB\Core\Moderation\Moderations\MergePosts'),
-				$app->make('MyBB\Core\Moderation\Moderations\DeletePost'),
-				$app->make('MyBB\Core\Moderation\Moderations\DeleteTopic'),
-				$app->make('MyBB\Core\Moderation\Moderations\Close'),
-				$app->make('MyBB\Core\Moderation\Moderations\MoveTopic')
+				$app->make(Moderations\Approve::class),
+				$app->make(Moderations\MovePost::class),
+				$app->make(Moderations\MergePosts::class),
+				$app->make(Moderations\DeletePost::class),
+				$app->make(Moderations\DeleteTopic::class),
+				$app->make(Moderations\Close::class),
+				$app->make(Moderations\MoveTopic::class)
 			]);
 		});
 
 		$this->app->bind(
-			'MyBB\Core\Database\Repositories\ModerationLogRepositoryInterface',
-			'MyBB\Core\Database\Repositories\Eloquent\ModerationLogRepository'
+			ModerationLogRepositoryInterface::class,
+			ModerationLogRepository::class
 		);
 
 		$this->app->bind(
-			'MyBB\Core\Database\Repositories\ModerationLogSubjectRepositoryInterface',
-			'MyBB\Core\Database\Repositories\Eloquent\ModerationLogSubjectRepository'
+			ModerationLogSubjectRepositoryInterface::class,
+			ModerationLogSubjectRepository::class
 		);
 
 		$this->app->bind(
-			'MyBB\Core\Moderation\Logger\ModerationLoggerInterface',
-			'MyBB\Core\Moderation\Logger\DatabaseLogger'
+			ModerationLoggerInterface::class,
+			DatabaseLogger::class
 		);
 	}
 }

--- a/app/Moderation/Moderations/Approve.php
+++ b/app/Moderation/Moderations/Approve.php
@@ -11,6 +11,7 @@ namespace MyBB\Core\Moderation\Moderations;
 use McCool\LaravelAutoPresenter\HasPresenter;
 use MyBB\Core\Moderation\ReversibleModerationInterface;
 use MyBB\Core\Moderation\SourceableInterface;
+use MyBB\Core\Presenters\Moderations\ApprovePresenter;
 
 class Approve implements ReversibleModerationInterface, HasPresenter, SourceableInterface
 {
@@ -112,7 +113,7 @@ class Approve implements ReversibleModerationInterface, HasPresenter, Sourceable
 	 */
 	public function getPresenterClass()
 	{
-		return 'MyBB\Core\Presenters\Moderations\ApprovePresenter';
+		return ApprovePresenter::class;
 	}
 
 	/**

--- a/app/Moderation/Moderations/Close.php
+++ b/app/Moderation/Moderations/Close.php
@@ -11,6 +11,7 @@ namespace MyBB\Core\Moderation\Moderations;
 use McCool\LaravelAutoPresenter\HasPresenter;
 use MyBB\Core\Moderation\ReversibleModerationInterface;
 use MyBB\Core\Moderation\SourceableInterface;
+use MyBB\Core\Presenters\Moderations\ClosePresenter;
 
 class Close implements ReversibleModerationInterface, HasPresenter, SourceableInterface
 {
@@ -112,7 +113,7 @@ class Close implements ReversibleModerationInterface, HasPresenter, SourceableIn
 	 */
 	public function getPresenterClass()
 	{
-		return 'MyBB\Core\Presenters\Moderations\ClosePresenter';
+		return ClosePresenter::class;
 	}
 
 	/**

--- a/app/Moderation/Moderations/DeletePost.php
+++ b/app/Moderation/Moderations/DeletePost.php
@@ -12,6 +12,7 @@ use McCool\LaravelAutoPresenter\HasPresenter;
 use MyBB\Core\Database\Models\Post;
 use MyBB\Core\Database\Repositories\PostRepositoryInterface;
 use MyBB\Core\Moderation\ModerationInterface;
+use MyBB\Core\Presenters\Moderations\DeletePostPresenter;
 
 class DeletePost implements ModerationInterface, HasPresenter
 {
@@ -93,7 +94,7 @@ class DeletePost implements ModerationInterface, HasPresenter
 	 */
 	public function getPresenterClass()
 	{
-		return 'MyBB\Core\Presenters\Moderations\DeletePostPresenter';
+		return DeletePostPresenter::class;
 	}
 
 	/**

--- a/app/Moderation/Moderations/DeleteTopic.php
+++ b/app/Moderation/Moderations/DeleteTopic.php
@@ -11,6 +11,7 @@ namespace MyBB\Core\Moderation\Moderations;
 use McCool\LaravelAutoPresenter\HasPresenter;
 use MyBB\Core\Database\Models\Topic;
 use MyBB\Core\Moderation\ModerationInterface;
+use MyBB\Core\Presenters\Moderations\DeleteTopicPresenter;
 use MyBB\Core\Services\TopicDeleter;
 
 class DeleteTopic implements ModerationInterface, HasPresenter
@@ -93,7 +94,7 @@ class DeleteTopic implements ModerationInterface, HasPresenter
 	 */
 	public function getPresenterClass()
 	{
-		return 'MyBB\Core\Presenters\Moderations\DeleteTopicPresenter';
+		return DeleteTopicPresenter::class;
 	}
 
 	/**

--- a/app/Moderation/Moderations/MergePosts.php
+++ b/app/Moderation/Moderations/MergePosts.php
@@ -13,6 +13,7 @@ use MyBB\Core\Database\Models\Post;
 use MyBB\Core\Database\Repositories\PostRepositoryInterface;
 use MyBB\Core\Moderation\ArrayModerationInterface;
 use MyBB\Core\Moderation\SourceableInterface;
+use MyBB\Core\Presenters\Moderations\MergePostsPresenter;
 
 class MergePosts implements ArrayModerationInterface, HasPresenter, SourceableInterface
 {
@@ -98,7 +99,7 @@ class MergePosts implements ArrayModerationInterface, HasPresenter, SourceableIn
 	 */
 	public function getPresenterClass()
 	{
-		return 'MyBB\Core\Presenters\Moderations\MergePostsPresenter';
+		return MergePostsPresenter::class;
 	}
 
 	/**

--- a/app/Moderation/Moderations/MovePost.php
+++ b/app/Moderation/Moderations/MovePost.php
@@ -15,6 +15,7 @@ use MyBB\Core\Database\Repositories\TopicRepositoryInterface;
 use MyBB\Core\Moderation\DestinedInterface;
 use MyBB\Core\Moderation\ModerationInterface;
 use MyBB\Core\Moderation\SourceableInterface;
+use MyBB\Core\Presenters\Moderations\MovePostPresenter;
 
 class MovePost implements ModerationInterface, HasPresenter, DestinedInterface, SourceableInterface
 {
@@ -88,7 +89,7 @@ class MovePost implements ModerationInterface, HasPresenter, DestinedInterface, 
 	 */
 	public function getPresenterClass()
 	{
-		return 'MyBB\Core\Presenters\Moderations\MovePostPresenter';
+		return MovePostPresenter::class;
 	}
 
 	/**

--- a/app/Moderation/Moderations/MoveTopic.php
+++ b/app/Moderation/Moderations/MoveTopic.php
@@ -15,6 +15,7 @@ use MyBB\Core\Database\Repositories\ForumRepositoryInterface;
 use MyBB\Core\Moderation\DestinedInterface;
 use MyBB\Core\Moderation\ModerationInterface;
 use MyBB\Core\Moderation\SourceableInterface;
+use MyBB\Core\Presenters\Moderations\MoveTopicPresenter;
 
 class MoveTopic implements ModerationInterface, HasPresenter, DestinedInterface, SourceableInterface
 {
@@ -98,7 +99,7 @@ class MoveTopic implements ModerationInterface, HasPresenter, DestinedInterface,
 	 */
 	public function getPresenterClass()
 	{
-		return 'MyBB\Core\Presenters\Moderations\MoveTopicPresenter';
+		return MoveTopicPresenter::class;
 	}
 
 	/**

--- a/app/Presenters/Conversation.php
+++ b/app/Presenters/Conversation.php
@@ -30,7 +30,7 @@ class Conversation extends BasePresenter
 	 */
 	public function __construct(ConversationModel $resource, Guard $guard)
 	{
-		$this->wrappedObject = $resource;
+		parent::__construct($resource);
 		$this->guard = $guard;
 	}
 

--- a/app/Presenters/ConversationMessage.php
+++ b/app/Presenters/ConversationMessage.php
@@ -22,7 +22,7 @@ class ConversationMessage extends BasePresenter
 	 */
 	public function __construct(ConversationMessageModel $resource)
 	{
-		$this->wrappedObject = $resource;
+		parent::__construct($resource);
 	}
 
 	/**

--- a/app/Presenters/Forum.php
+++ b/app/Presenters/Forum.php
@@ -36,7 +36,7 @@ class Forum extends BasePresenter
 	 */
 	public function __construct(ForumModel $resource, Application $app, ModerationRegistry $moderations)
 	{
-		$this->wrappedObject = $resource;
+		parent::__construct($resource);
 		$this->app = $app;
 		$this->moderations = $moderations;
 	}

--- a/app/Presenters/Poll.php
+++ b/app/Presenters/Poll.php
@@ -44,7 +44,7 @@ class Poll extends BasePresenter
 		PollVoteRepositoryInterface $pollVoteRepository,
 		Guard $guard
 	) {
-		$this->wrappedObject = $resource;
+		parent::__construct($resource);
 		$this->pollVoteRepository = $pollVoteRepository;
 		$this->guard = $guard;
 	}

--- a/app/Presenters/Post.php
+++ b/app/Presenters/Post.php
@@ -38,7 +38,7 @@ class Post extends BasePresenter
 	 */
 	public function __construct(PostModel $resource, Guard $guard, Application $app)
 	{
-		$this->wrappedObject = $resource;
+		parent::__construct($resource);
 		$this->guard = $guard;
 		$this->app = $app;
 	}

--- a/app/Presenters/ProfileFieldGroup.php
+++ b/app/Presenters/ProfileFieldGroup.php
@@ -27,7 +27,7 @@ class ProfileFieldGroup extends BasePresenter
 	 */
 	public function __construct(ProfileFieldGroupModel $resource, Application $app)
 	{
-		$this->wrappedObject = $resource;
+		parent::__construct($resource);
 		$this->app = $app;
 	}
 

--- a/app/Presenters/Topic.php
+++ b/app/Presenters/Topic.php
@@ -38,7 +38,7 @@ class Topic extends BasePresenter
 	 */
 	public function __construct(TopicModel $resource, ModerationRegistry $moderations, Application $app)
 	{
-		$this->wrappedObject = $resource;
+		parent::__construct($resource);
 		$this->moderations = $moderations;
 		$this->app = $app;
 	}

--- a/app/Presenters/User.php
+++ b/app/Presenters/User.php
@@ -115,7 +115,7 @@ class User extends BasePresenter
 		Store $settings,
 		Guard $guard
 	) {
-		$this->wrappedObject = $resource;
+		parent::__construct($resource);
 		$this->router = $router;
 		$this->forumRepository = $forumRepository;
 		$this->topicRepository = $topicRepository;


### PR DESCRIPTION
I noticed a few small code cleanliness issues whilst reviewing code. This PR is a work in progress to clean some of these up. The steps are:
- [X] Ensure presenters call `parent::__construct()`.
- [ ] Use the PHP 5.5 `::class` prefix rather than hard coded strings. This makes working with IDEs and refactoring easier as you can jump straight to classes from Service Providers and elsewhere.

There are probably other issues I'll notice and fix over time. 

Signed-off-by: Euan Torano euantorano@gmail.com
