### PR TITLE
Fix compile error on windows

### DIFF
--- a/config/compile.php
+++ b/config/compile.php
@@ -16,7 +16,6 @@ return [
 	'files' => [
 
 		realpath(__DIR__ . '/../app/Providers/AppServiceProvider.php'),
-		realpath(__DIR__ . '/../app/Providers/BusServiceProvider.php'),
 		realpath(__DIR__ . '/../app/Providers/ConfigServiceProvider.php'),
 		realpath(__DIR__ . '/../app/Providers/EventServiceProvider.php'),
 		realpath(__DIR__ . '/../app/Providers/RouteServiceProvider.php'),


### PR DESCRIPTION
This fixes the following error that you get when generating classes on windows: 
[ErrorException]                                                                                 
php_strip_whitespace(): failed to open stream