### PR TITLE
Added stick/unstick topic mod option

### DIFF
--- a/app/Database/Models/Forum.php
+++ b/app/Database/Models/Forum.php
@@ -14,13 +14,15 @@ use Kalnoy\Nestedset\Node;
 use McCool\LaravelAutoPresenter\HasPresenter;
 use MyBB\Core\Content\ContentInterface;
 use MyBB\Core\Moderation\Moderations\CloseableInterface;
+use MyBB\Core\Moderation\Moderations\StickableInterface;
 use MyBB\Core\Permissions\Interfaces\InheritPermissionInterface;
 use MyBB\Core\Permissions\Traits\InheritPermissionableTrait;
+use MyBB\Core\Presenters\ForumPresenter;
 
 /**
  * @property int id
  */
-class Forum extends Node implements HasPresenter, InheritPermissionInterface, CloseableInterface, ContentInterface
+class Forum extends Node implements HasPresenter, InheritPermissionInterface, CloseableInterface, StickableInterface, ContentInterface
 {
     use InheritPermissionableTrait;
 
@@ -74,7 +76,7 @@ class Forum extends Node implements HasPresenter, InheritPermissionInterface, Cl
      */
     public function getPresenterClass()
     {
-        return 'MyBB\Core\Presenters\ForumPresenter';
+        return ForumPresenter::class;
     }
 
     /**
@@ -91,23 +93,23 @@ class Forum extends Node implements HasPresenter, InheritPermissionInterface, Cl
     }
 
     /**
-     * A forum contains many threads.
+     * A forum contains many topics.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function topics()
     {
-        return $this->hasMany('MyBB\\Core\\Database\\Models\\Topic');
+        return $this->hasMany(\MyBB\Core\Database\Models\Topic::class);
     }
 
     /**
-     * A forum contains many posts, through its threads.
+     * A forum contains many posts, through its topics.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
     public function posts()
     {
-        return $this->hasManyThrough('MyBB\\Core\\Database\\Models\\Post', 'MyBB\\Core\\Database\\Models\\Topic');
+        return $this->hasManyThrough(\MyBB\Core\Database\Models\Post::class, \MyBB\Core\Database\Models\Topic::class);
     }
 
     /**
@@ -117,7 +119,7 @@ class Forum extends Node implements HasPresenter, InheritPermissionInterface, Cl
      */
     public function lastPost()
     {
-        return $this->hasOne('MyBB\\Core\\Database\\Models\\Post', 'id', 'last_post_id');
+        return $this->hasOne(\MyBB\Core\Database\Models\Post::class, 'id', 'last_post_id');
     }
 
     /**
@@ -127,7 +129,7 @@ class Forum extends Node implements HasPresenter, InheritPermissionInterface, Cl
      */
     public function lastPostAuthor()
     {
-        return $this->hasOne('MyBB\\Core\\Database\\Models\\User', 'id', 'last_post_user_id');
+        return $this->hasOne(\MyBB\Core\Database\Models\User::class, 'id', 'last_post_user_id');
     }
 
     /**
@@ -144,6 +146,22 @@ class Forum extends Node implements HasPresenter, InheritPermissionInterface, Cl
     public function open()
     {
         return $this->update(['closed' => 0]);
+    }
+
+    /**
+     * @return bool|int
+     */
+    public function stick()
+    {
+        return $this->update(['sticky' => 1]);
+    }
+
+    /**
+     * @return bool|int
+     */
+    public function unstick()
+    {
+        return $this->update(['sticky' => 0]);
     }
 
     /**

--- a/app/Database/Models/Topic.php
+++ b/app/Database/Models/Topic.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Thread model class.
+ * Topic model class.
  *
  * @author    MyBB Group
  * @version   2.0.0
@@ -16,6 +16,7 @@ use McCool\LaravelAutoPresenter\HasPresenter;
 use MyBB\Core\Content\ContentInterface;
 use MyBB\Core\Moderation\Moderations\ApprovableInterface;
 use MyBB\Core\Moderation\Moderations\CloseableInterface;
+use MyBB\Core\Moderation\Moderations\StickableInterface;
 use MyBB\Core\Presenters\TopicPresenter;
 
 /**
@@ -23,7 +24,7 @@ use MyBB\Core\Presenters\TopicPresenter;
  * @property Forum forum
  * @property int forum_id
  */
-class Topic extends Model implements HasPresenter, ApprovableInterface, CloseableInterface, ContentInterface
+class Topic extends Model implements HasPresenter, ApprovableInterface, CloseableInterface, StickableInterface, ContentInterface
 {
     use SoftDeletes;
 
@@ -103,7 +104,7 @@ class Topic extends Model implements HasPresenter, ApprovableInterface, Closeabl
     }
 
     /**
-     * A thread has many contributors (authors of posts belonging to the thread).
+     * A topic has many contributors (authors of posts belonging to the topic).
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
@@ -113,7 +114,7 @@ class Topic extends Model implements HasPresenter, ApprovableInterface, Closeabl
     }
 
     /**
-     * A thread belongs to one forum.
+     * A topic belongs to one forum.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
@@ -123,7 +124,7 @@ class Topic extends Model implements HasPresenter, ApprovableInterface, Closeabl
     }
 
     /**
-     * A thread is created by (and belongs to) a user/author.
+     * A topic is created by (and belongs to) a user/author.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
@@ -136,7 +137,7 @@ class Topic extends Model implements HasPresenter, ApprovableInterface, Closeabl
     // TODO: Will probably be quicker to store last post and first post ID than alternatives...
 
     /**
-     * A thread has a single first post.
+     * A topic has a single first post.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
@@ -146,7 +147,7 @@ class Topic extends Model implements HasPresenter, ApprovableInterface, Closeabl
     }
 
     /**
-     * A thread has a single last post.
+     * A topic has a single last post.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
@@ -197,6 +198,22 @@ class Topic extends Model implements HasPresenter, ApprovableInterface, Closeabl
     public function open()
     {
         return $this->update(['closed' => 0]);
+    }
+
+    /**
+     * @return bool|int
+     */
+    public function stick()
+    {
+        return $this->update(['sticky' => 1]);
+    }
+
+    /**
+     * @return bool|int
+     */
+    public function unstick()
+    {
+        return $this->update(['sticky' => 0]);
     }
 
     /**

--- a/app/Database/Repositories/Eloquent/TopicRepository.php
+++ b/app/Database/Repositories/Eloquent/TopicRepository.php
@@ -69,7 +69,7 @@ class TopicRepository implements TopicRepositoryInterface
     private $permissionChecker;
 
     /**
-     * @param Topic $topicModel The model to use for threads.
+     * @param Topic $topicModel The model to use for topics.
      * @param Guard $guard Laravel guard instance, used to get user ID.
      * @param PostRepositoryInterface $postRepository Used to manage posts for topics.
      * @param Str $stringUtils String utilities, used for creating slugs.
@@ -102,7 +102,7 @@ class TopicRepository implements TopicRepositoryInterface
     }
 
     /**
-     * Get all threads.
+     * Get all topics.
      *
      * @return mixed
      */
@@ -122,7 +122,7 @@ class TopicRepository implements TopicRepositoryInterface
     }
 
     /**
-     * Get all threads created by a user.
+     * Get all topics created by a user.
      *
      * @param int $userId The ID of the user.
      *
@@ -138,7 +138,7 @@ class TopicRepository implements TopicRepositoryInterface
     /**
      * Find a single topic by ID.
      *
-     * @param int $id The ID of the thread to find.
+     * @param int $id The ID of the topic to find.
      *
      * @return mixed
      */
@@ -152,7 +152,7 @@ class TopicRepository implements TopicRepositoryInterface
     /**
      * Find a single topic by its slug.
      *
-     * @param string $slug The slug of the thread. Eg: 'my-first-thread'.
+     * @param string $slug The slug of the topic. Eg: 'my-first-topic'.
      *
      * @return mixed
      */
@@ -183,9 +183,9 @@ class TopicRepository implements TopicRepositoryInterface
     }
 
     /**
-     * Get all threads within a forum.
+     * Get all topics within a forum.
      *
-     * @param Forum $forum The forum the threads belong to.
+     * @param Forum $forum The forum the topics belong to.
      * @param string $orderBy The order by column
      * @param string $orderDir asc|desc
      *
@@ -211,7 +211,7 @@ class TopicRepository implements TopicRepositoryInterface
 
         return $this->topicModel->withTrashed()->with(['author', 'lastPost', 'lastPost.author'])
             ->leftJoin('posts', 'last_post_id', '=', 'posts.id')->where('forum_id', '=', $forum->id)
-            ->orderBy($orderBy, $orderDir)->paginate($topicsPerPage, ['topics.*']);
+            ->orderBy('sticky', 'desc')->orderBy($orderBy, $orderDir)->paginate($topicsPerPage, ['topics.*']);
     }
 
     /**

--- a/app/Moderation/ModerationServiceProvider.php
+++ b/app/Moderation/ModerationServiceProvider.php
@@ -28,6 +28,7 @@ class ModerationServiceProvider extends ServiceProvider
                 $app->make('MyBB\Core\Moderation\Moderations\DeletePost'),
                 $app->make('MyBB\Core\Moderation\Moderations\DeleteTopic'),
                 $app->make('MyBB\Core\Moderation\Moderations\Close'),
+                $app->make('MyBB\Core\Moderation\Moderations\Stick'),
                 $app->make('MyBB\Core\Moderation\Moderations\MoveTopic'),
             ]);
         });

--- a/app/Moderation/ModerationServiceProvider.php
+++ b/app/Moderation/ModerationServiceProvider.php
@@ -28,7 +28,7 @@ class ModerationServiceProvider extends ServiceProvider
                 $app->make('MyBB\Core\Moderation\Moderations\DeletePost'),
                 $app->make('MyBB\Core\Moderation\Moderations\DeleteTopic'),
                 $app->make('MyBB\Core\Moderation\Moderations\Close'),
-                $app->make('MyBB\Core\Moderation\Moderations\Stick'),
+                $app->make(\MyBB\Core\Moderation\Moderations\Stick::class),
                 $app->make('MyBB\Core\Moderation\Moderations\MoveTopic'),
             ]);
         });

--- a/app/Moderation/Moderations/Stick.php
+++ b/app/Moderation/Moderations/Stick.php
@@ -28,7 +28,7 @@ class Stick implements ReversibleModerationInterface, HasPresenter, SourceableIn
      */
     public function getName()
     {
-        return 'Stick';
+        return 'forum.moderate.stick';
     }
 
     /**
@@ -103,7 +103,7 @@ class Stick implements ReversibleModerationInterface, HasPresenter, SourceableIn
      */
     public function getReverseName()
     {
-        return 'Unstick';
+        return 'forum.moderate.unstick';
     }
 
     /**

--- a/app/Moderation/Moderations/Stick.php
+++ b/app/Moderation/Moderations/Stick.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @author    MyBB Group
+ * @version   2.0.0
+ * @package   mybb/core
+ * @license   http://www.mybb.com/licenses/bsd3 BSD-3
+ */
+
+namespace MyBB\Core\Moderation\Moderations;
+
+use McCool\LaravelAutoPresenter\HasPresenter;
+use MyBB\Core\Moderation\ReversibleModerationInterface;
+use MyBB\Core\Moderation\SourceableInterface;
+use MyBB\Core\Presenters\Moderations\StickPresenter;
+
+class Stick implements ReversibleModerationInterface, HasPresenter, SourceableInterface
+{
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return 'stick';
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Stick';
+    }
+
+    /**
+     * @param StickableInterface $stickable
+     *
+     * @return mixed
+     */
+    public function stick(StickableInterface $stickable)
+    {
+        return $stickable->stick();
+    }
+
+    /**
+     * @param StickableInterface $stickable
+     *
+     * @return mixed
+     */
+    public function unstick(StickableInterface $stickable)
+    {
+        return $stickable->unstick();
+    }
+
+    /**
+     * @param mixed $content
+     * @param array $options
+     *
+     * @return mixed
+     */
+    public function apply($content, array $options = [])
+    {
+        if ($this->supports($content)) {
+            return $this->stick($content);
+        }
+    }
+
+    /**
+     * @param mixed $content
+     * @param array $options
+     *
+     * @return bool
+     */
+    public function supports($content, array $options = [])
+    {
+        return $content instanceof StickableInterface;
+    }
+
+    /**
+     * @param mixed $content
+     *
+     * @return bool
+     */
+    public function visible($content)
+    {
+        return $content instanceof StickableInterface;
+    }
+
+    /**
+     * @param mixed $content
+     * @param array $options
+     *
+     * @return mixed
+     */
+    public function reverse($content, array $options = [])
+    {
+        if ($this->supports($content)) {
+            return $this->unstick($content);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getReverseName()
+    {
+        return 'Unstick';
+    }
+
+    /**
+     * Get the presenter class.
+     *
+     * @return string
+     */
+    public function getPresenterClass()
+    {
+        return StickPresenter::class;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPermissionName()
+    {
+        return 'canStick';
+    }
+}

--- a/app/Moderation/Moderations/StickableInterface.php
+++ b/app/Moderation/Moderations/StickableInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @author    MyBB Group
+ * @version   2.0.0
+ * @package   mybb/core
+ * @license   http://www.mybb.com/licenses/bsd3 BSD-3
+ */
+
+namespace MyBB\Core\Moderation\Moderations;
+
+interface StickableInterface
+{
+    public function stick();
+
+    public function unstick();
+}

--- a/app/Presenters/Moderations/StickPresenter.php
+++ b/app/Presenters/Moderations/StickPresenter.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @author    MyBB Group
+ * @version   2.0.0
+ * @package   mybb/core
+ * @license   http://www.mybb.com/licenses/bsd3 BSD-3
+ */
+
+namespace MyBB\Core\Presenters\Moderations;
+
+use MyBB\Core\Moderation\Moderations\Stick;
+
+class StickPresenter extends AbstractReversibleModerationPresenter implements ReversibleModerationPresenterInterface
+{
+    /**
+     * @return Stick
+     */
+    public function getWrappedObject()
+    {
+        return parent::getWrappedObject();
+    }
+
+    /**
+     * @return string
+     */
+    public function icon()
+    {
+        return 'fa-sticky-note';
+    }
+
+    /**
+     * @return string
+     */
+    public function reverseIcon()
+    {
+        return 'fa-sticky-note-o';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDescriptionView()
+    {
+        return 'partials.moderation.logs.stick';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getReverseDescriptionView()
+    {
+        return 'partials.moderation.logs.unstick';
+    }
+}

--- a/database/migrations/2016_09_06_134433_add_sticky_to_topics_tables.php
+++ b/database/migrations/2016_09_06_134433_add_sticky_to_topics_tables.php
@@ -5,27 +5,27 @@ use Illuminate\Database\Migrations\Migration;
 
 class AddStickyToTopicsTables extends Migration
 {
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up()
-	{
-		Schema::table('topics', function (Blueprint $table) {
-			$table->tinyInteger('sticky')->unsigned()->default(0)->index();
-		});
-	}
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('topics', function (Blueprint $table) {
+            $table->boolean('sticky')->default(0)->index();
+        });
+    }
 
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down()
-	{
-		Schema::table('topics', function (Blueprint $table) {
-			$table->dropColumn('sticky');
-		});
-	}
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('topics', function (Blueprint $table) {
+            $table->dropColumn('sticky');
+        });
+    }
 }

--- a/database/migrations/2016_09_06_134433_add_sticky_to_topics_tables.php
+++ b/database/migrations/2016_09_06_134433_add_sticky_to_topics_tables.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddStickyToTopicsTables extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('topics', function (Blueprint $table) {
+			$table->tinyInteger('sticky')->unsigned()->default(0)->index();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('topics', function (Blueprint $table) {
+			$table->dropColumn('sticky');
+		});
+	}
+}

--- a/database/seeds/PermissionRoleTableSeeder.php
+++ b/database/seeds/PermissionRoleTableSeeder.php
@@ -73,6 +73,12 @@ class PermissionRoleTableSeeder extends Seeder
                 'value'         => 1,
             ],
             [
+                'permission_id' => DB::table('permissions')->where('permission_name', '=', 'canStick')
+                    ->first()->id,
+                'role_id'       => DB::table('roles')->where('role_slug', '=', 'admin')->first()->id,
+                'value'         => 1,
+            ],
+            [
                 'permission_id' => DB::table('permissions')->where('permission_name', '=', 'canDeletePosts')
                     ->first()->id,
                 'role_id'       => DB::table('roles')->where('role_slug', '=', 'admin')->first()->id,

--- a/database/seeds/PermissionsTableSeeder.php
+++ b/database/seeds/PermissionsTableSeeder.php
@@ -62,6 +62,11 @@ class PermissionsTableSeeder extends Seeder
                 'default_value'   => 0,
             ],
             [
+                'permission_name' => 'canStick',
+                'content_name'    => null,
+                'default_value'   => 0,
+            ],
+            [
                 'permission_name' => 'canDeletePosts',
                 'content_name'    => null,
                 'default_value'   => 0,

--- a/resources/lang/en/forum.php
+++ b/resources/lang/en/forum.php
@@ -23,4 +23,9 @@ return [
     'closedtopic' => 'Closed Topic',
     'stickytopic' => 'Sticky Topic',
     'poll'        => 'Topic Contains Poll',
+
+    'moderate' => [
+        'stick'    => 'Stick',
+        'unstick'  => 'Unstick',
+    ],
 ];

--- a/resources/lang/en/forum.php
+++ b/resources/lang/en/forum.php
@@ -21,5 +21,6 @@ return [
     'author'      => 'Author',
     'sorttopics'  => 'Sort Topics',
     'closedtopic' => 'Closed Topic',
+    'stickytopic' => 'Sticky Topic',
     'poll'        => 'Topic Contains Poll',
 ];

--- a/resources/lang/en/moderation.php
+++ b/resources/lang/en/moderation.php
@@ -19,4 +19,7 @@ return [
     'reports_title'                   => 'Reports',
     'logs_title'                      => 'Logs',
     'empty_queue'                     => 'The moderation queue is empty.',
+
+    'sticked'                         => 'Sticked',
+    'unsticked'                       => 'Unsticked',
 ];

--- a/resources/views/forum/show.twig
+++ b/resources/views/forum/show.twig
@@ -110,6 +110,9 @@
                                 <h3 class="topic__title">
                                     <a href="{{ url_route("topics.show", {'slug': topic.slug, 'id': topic.id}) }}">{{ topic.title }}</a>
                                     <span class="topic__icons icons">
+                                        {% if topic.sticky == true %}
+                                        <i class="fa fa-thumb-tack fa-fw" title="{{ trans('forum.stickytopic') }}"></i>
+                                        {% endif %}
                                         {% if topic.closed == true %}
                                         <i class="fa fa-lock fa-fw" title="{{ trans('forum.closedtopic') }}"></i>
                                         {% endif %}

--- a/resources/views/partials/moderation/logs/stick.twig
+++ b/resources/views/partials/moderation/logs/stick.twig
@@ -1,0 +1,1 @@
+sticked <a href="{{ url }}">{{ title ?: count ~ ' ' ~ type }}</a> in <a href="{{ source_url }}">{{ source_title }}</a>

--- a/resources/views/partials/moderation/logs/stick.twig
+++ b/resources/views/partials/moderation/logs/stick.twig
@@ -1,1 +1,1 @@
-sticked <a href="{{ url }}">{{ title ?: count ~ ' ' ~ type }}</a> in <a href="{{ source_url }}">{{ source_title }}</a>
+{{ trans('moderation.sticked') }} <a href="{{ url }}">{{ title ?: count ~ ' ' ~ type }}</a> in <a href="{{ source_url }}">{{ source_title }}</a>

--- a/resources/views/partials/moderation/logs/unstick.twig
+++ b/resources/views/partials/moderation/logs/unstick.twig
@@ -1,1 +1,1 @@
-unsticked <a href="{{ url }}">{{ title ?: count ~ ' ' ~ type }}</a> in <a href="{{ source_url }}">{{ source_title }}</a>
+{{ trans('moderation.unsticked') }} <a href="{{ url }}">{{ title ?: count ~ ' ' ~ type }}</a> in <a href="{{ source_url }}">{{ source_title }}</a>

--- a/resources/views/partials/moderation/logs/unstick.twig
+++ b/resources/views/partials/moderation/logs/unstick.twig
@@ -1,0 +1,1 @@
+unsticked <a href="{{ url }}">{{ title ?: count ~ ' ' ~ type }}</a> in <a href="{{ source_url }}">{{ source_title }}</a>

--- a/resources/views/partials/moderation/moderation_bar.twig
+++ b/resources/views/partials/moderation/moderation_bar.twig
@@ -4,13 +4,13 @@
         {% for moderation in moderations %}
             {% if moderation.getPermissionName is empty or (moderation.getPermissionName is not empty and auth_user.hasPermission(moderation.getPermissionName)) %}
                 {% if moderation.fields is not empty %}
-                    <li class="{{ moderation.key }}" {{ is_array_moderation(moderation) ? 'data-moderation-multi="true"' }}><a href="#" data-modal="moderate/form/{{ moderation.key }}" onclick="window.MyBB.Moderation.injectModalParams(this);"><i class="fa {{ moderation.icon }}"></i><span class="text">{{ moderation.name }}</span></a></li>
+                    <li class="{{ moderation.key }}" {{ is_array_moderation(moderation) ? 'data-moderation-multi="true"' }}><a href="#" data-modal="moderate/form/{{ moderation.key }}" onclick="window.MyBB.Moderation.injectModalParams(this);"><i class="fa {{ moderation.icon }}"></i><span class="text">{{ trans(moderation.name) }}</span></a></li>
                 {% else %}
-                    <li class="{{ moderation.key }}" {{ is_array_moderation(moderation) ? 'data-moderation-multi="true"' }}><a href="#" data-moderate="{{ moderation.key }}"><i class="fa {{ moderation.icon }}"></i><span class="text">{{ moderation.name }}</span></a></li>
+                    <li class="{{ moderation.key }}" {{ is_array_moderation(moderation) ? 'data-moderation-multi="true"' }}><a href="#" data-moderate="{{ moderation.key }}"><i class="fa {{ moderation.icon }}"></i><span class="text">{{ trans(moderation.name) }}</span></a></li>
                 {% endif %}
 
                 {% if is_reversible_moderation(moderation) %}
-                    <li class="{{ moderation.key }}"><a href="#" data-moderate-reverse="{{ moderation.key }}"><i class="fa {{ moderation.reverseIcon }}"></i><span class="text">{{ moderation.reverseName }}</span></a></li>
+                    <li class="{{ moderation.key }}"><a href="#" data-moderate-reverse="{{ moderation.key }}"><i class="fa {{ moderation.reverseIcon }}"></i><span class="text">{{ trans(moderation.reverseName) }}</span></a></li>
                 {% endif %}
             {% endif %}
         {% endfor %}

--- a/tests/unit/Moderation/Moderations/StickTest.php
+++ b/tests/unit/Moderation/Moderations/StickTest.php
@@ -13,7 +13,7 @@ class StickTest extends \PHPUnit_Framework_TestCase
     public function testCanBeConstructed()
     {
         $stick = new Stick();
-        static::assertInstanceOf('MyBB\Core\Moderation\Moderations\Stick', $stick);
+        static::assertInstanceOf(\MyBB\Core\Moderation\Moderations\Stick::class, $stick);
     }
 
     public function testCanStickStickableInterface()
@@ -40,7 +40,7 @@ class StickTest extends \PHPUnit_Framework_TestCase
 
     public function testHasKeyThatIsAString()
     {
-        $stick = new stick();
+        $stick = new Stick();
         $key = $stick->getKey();
         static::assertInternalType('string', $key);
     }

--- a/tests/unit/Moderation/Moderations/StickTest.php
+++ b/tests/unit/Moderation/Moderations/StickTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace MyBB\Core\Moderation\Moderations;
+
+use Mockery;
+use MyBB\Core\Test\ClassAssertionsTrait;
+use stdClass;
+
+class StickTest extends \PHPUnit_Framework_TestCase
+{
+    use ClassAssertionsTrait;
+
+    public function testCanBeConstructed()
+    {
+        $stick = new Stick();
+        static::assertInstanceOf('MyBB\Core\Moderation\Moderations\Stick', $stick);
+    }
+
+    public function testCanStickStickableInterface()
+    {
+        $stickable = Mockery::mock('MyBB\Core\Moderation\Moderations\StickableInterface');
+        $stickable->shouldReceive('stick')
+            ->withNoArgs()
+            ->once();
+
+        $stick = new Stick();
+        $stick->stick($stickable);
+    }
+
+    public function testCanUnstickStickableInterface()
+    {
+        $stickable = Mockery::mock('MyBB\Core\Moderation\Moderations\StickableInterface');
+        $stickable->shouldReceive('unstick')
+            ->withNoArgs()
+            ->once();
+
+        $stick = new Stick();
+        $stick->unstick($stickable);
+    }
+
+    public function testHasKeyThatIsAString()
+    {
+        $stick = new stick();
+        $key = $stick->getKey();
+        static::assertInternalType('string', $key);
+    }
+
+    public function testSupportsStickableContent()
+    {
+        $stick = new Stick();
+        static::assertTrue($stick->supports(Mockery::mock('MyBB\Core\Moderation\Moderations\StickableInterface')));
+    }
+
+    public function testDoesNotSupportInvalidContent()
+    {
+        $stick = new Stick();
+        static::assertFalse($stick->supports(1));
+        static::assertFalse($stick->supports('1'));
+        static::assertFalse($stick->supports('foo'));
+        static::assertFalse($stick->supports(new stdClass()));
+    }
+
+    public function testCanBeAppliedToSupportedContent()
+    {
+        $stickable = Mockery::mock('MyBB\Core\Moderation\Moderations\StickableInterface');
+        $stickable->shouldReceive('stick')
+            ->withNoArgs()
+            ->once()
+            ->andReturn(true);
+
+        $stick = new Stick();
+        static::assertNotNull($stick->apply($stickable));
+    }
+
+    public function testDoesNotApplyToUnsupportedContent()
+    {
+        $stick = new Stick();
+        static::assertNull($stick->apply(1));
+        static::assertNull($stick->apply('1'));
+        static::assertNull($stick->apply('foo'));
+        static::assertNull($stick->apply(new stdClass()));
+    }
+
+    public function testCanBeReversedForSupportedContent()
+    {
+        $stickable = Mockery::mock('MyBB\Core\Moderation\Moderations\StickableInterface');
+        $stickable->shouldReceive('unstick')
+            ->withNoArgs()
+            ->once()
+            ->andReturn(true);
+
+        $stick = new Stick();
+        static::assertNotNull($stick->reverse($stickable));
+    }
+
+    public function testDoesNotReverseForUnsupportedContent()
+    {
+        $stick = new Stick();
+        static::assertNull($stick->reverse(1));
+        static::assertNull($stick->reverse('1'));
+        static::assertNull($stick->reverse('foo'));
+        static::assertNull($stick->reverse(new stdClass()));
+    }
+
+    public function testIsVisibleForValidContent()
+    {
+        $stick = new Stick();
+        static::assertTrue($stick->visible(Mockery::mock('MyBB\Core\Moderation\Moderations\StickableInterface')));
+    }
+
+    public function testIsNotVisibleForInvalidContent()
+    {
+        $stick = new Stick();
+        static::assertFalse($stick->supports(1));
+        static::assertFalse($stick->supports('1'));
+        static::assertFalse($stick->supports('foo'));
+        static::assertFalse($stick->supports(new stdClass()));
+    }
+
+    public function testCanGetNameAsString()
+    {
+        $stick = new Stick();
+
+        static::assertInternalType('string', $stick->getName());
+    }
+
+    public function testCanGetReverseNameAsString()
+    {
+        $stick = new Stick();
+
+        static::assertInternalType('string', $stick->getReverseName());
+    }
+
+    public function testCanGetPresenterClassAsString()
+    {
+        $stick = new Stick();
+
+        static::assertInternalType('string', $stick->getPresenterClass());
+    }
+
+    public function testCanGetValidPresenterClassName()
+    {
+        $stick = new Stick();
+
+        static::assertClassExtends($stick->getPresenterClass(), 'McCool\LaravelAutoPresenter\BasePresenter');
+    }
+
+    public function testCanGetPermissionNameAsString()
+    {
+        $stick = new Stick();
+
+        static::assertInternalType('string', $stick->getPermissionName());
+    }
+}


### PR DESCRIPTION
Adds the ability to stick/unstick topics. Last mod option listed in #45 to be added.

Since the moderation javascript is broken, I can't test if the front end tools work. However the sticking ability works if you edit the database field directly.