### PR TITLE
Removing HHVM as discussed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 php:
   - 7.0
-  - hhvm
 
 sudo: false
 


### PR DESCRIPTION
As we discussed internally we need to remove HHVM as they don't support return type hints.