### PR TITLE
Fixes #203 Search

### DIFF
--- a/app/Database/Models/Search.php
+++ b/app/Database/Models/Search.php
@@ -35,7 +35,7 @@ class Search extends Model
      * @var array
      */
     protected $fillable = [
-        'id',
+        'token',
         'as_topics',
         'user_id',
         'topics',
@@ -53,7 +53,7 @@ class Search extends Model
      *
      * @var string
      */
-    protected $primaryKey = 'id';
+    protected $primaryKey = 'token';
     /**
      * The database table used by the model.
      *

--- a/app/Database/Repositories/Eloquent/SearchRepository.php
+++ b/app/Database/Repositories/Eloquent/SearchRepository.php
@@ -38,20 +38,20 @@ class SearchRepository implements SearchRepositoryInterface
     }
 
     /**
-     * Find a single searchlog by ID.
+     * Find a single searchlog by token.
      *
-     * @param string $id The ID of the search to find.
+     * @param string $token The token of the search to find.
      *
      * @return mixed
      */
-    public function find($id)
+    public function find($token)
     {
-        $userId = $this->guard->user()->getAuthIdentifier();
+        $userId = $this->guard->user() != null ? $this->guard->user()->getAuthIdentifier() : null;
         if ($userId <= 0) {
             $userId = null;
         }
 
-        return $this->searchModel->where('user_id', $userId)->find($id);
+        return $this->searchModel->where('user_id', $userId)->find($token);
     }
 
     /**
@@ -64,10 +64,10 @@ class SearchRepository implements SearchRepositoryInterface
     public function create(array $details = [])
     {
         $details = array_merge([
-            'id'        => md5(uniqid(microtime(), true)),
+            'token'     => md5(uniqid(microtime(), true)),
             'keywords'  => '',
             'as_topics' => true,
-            'user_id'   => $this->guard->user()->getAuthIdentifier(),
+            'user_id'   => $this->guard->user() != null ? $this->guard->user()->getAuthIdentifier() : null,
             'topics'    => '',
             'posts'     => '',
         ], $details);

--- a/app/Database/Repositories/SearchRepositoryInterface.php
+++ b/app/Database/Repositories/SearchRepositoryInterface.php
@@ -14,13 +14,13 @@ interface SearchRepositoryInterface
 {
 
     /**
-     * Find a single search log by ID.
+     * Find a single search log by token.
      *
-     * @param string $id The ID of the search log to find.
+     * @param string $token The token of the search log to find.
      *
      * @return mixed
      */
-    public function find($id);
+    public function find($token);
 
     /**
      * Create a new searchlog

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -247,7 +247,7 @@ class SearchController extends AbstractController
         ]);
 
         return redirect()->route('search.results', [
-            'token'       => $searchlog->id,
+            'token'    => $searchlog->token,
             'orderBy'  => $searchRequest->sortby,
             'orderDir' => $searchRequest->sorttype,
         ]);

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -247,23 +247,23 @@ class SearchController extends AbstractController
         ]);
 
         return redirect()->route('search.results', [
-            'id'       => $searchlog->id,
+            'token'       => $searchlog->id,
             'orderBy'  => $searchRequest->sortby,
             'orderDir' => $searchRequest->sorttype,
         ]);
     }
 
     /**
-     * @param int $id
+     * @param string $token
      * @param Request $request
      * @param Breadcrumbs $breadcrumbs
      *
      * @return \Illuminate\View\View
      */
-    public function results($id, Request $request, Breadcrumbs $breadcrumbs)
+    public function results($token, Request $request, Breadcrumbs $breadcrumbs)
     {
         // TODO: sorts
-        $search = $this->searchRepository->find($id);
+        $search = $this->searchRepository->find($token);
         if (!$search) {
             throw new NotFoundHttpException();
         }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -67,7 +67,7 @@ Route::group(['middleware' => ['web']], function () {
 
     Route::get('search', ['as' => 'search', 'uses' => 'SearchController@index']);
     Route::post('search', ['as' => 'search.post', 'uses' => 'SearchController@makeSearch']);
-    Route::get('search/{id}', ['as' => 'search.results', 'uses' => 'SearchController@results']);
+    Route::get('search/{token}', ['as' => 'search.results', 'uses' => 'SearchController@results']);
 
     Route::controllers([
         'auth'     => 'Auth\AuthController',

--- a/database/migrations/2016_11_04_190327_rename_search_id_to_token.php
+++ b/database/migrations/2016_11_04_190327_rename_search_id_to_token.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameSearchIdToToken extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('searchlog', function (Blueprint $table) {
+            $table->renameColumn('id', 'token');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('searchlog', function (Blueprint $table) {
+            $table->renameColumn('token', 'id');
+        });
+    }
+}

--- a/resources/views/search/result_topics.twig
+++ b/resources/views/search/result_topics.twig
@@ -53,7 +53,7 @@
         </div>
         <div class="topic-list__container">
             {% for topic in results %}
-                <div class="topic{{ topic.trashed ? ' soft-deleted' }}">
+                <div class="topic{{ topic.trashed() ? ' soft-deleted' }}">
                     <div class="primary-column">
                         <h3 class="topic__title">
                             <a href="{{ url_route("topics.show", {'slug': topic.slug, 'id': topic.id}) }}">{{ topic.title }}</a>


### PR DESCRIPTION
#203

Problem was that we assume that `id` is always an integer and add a pattern for that: https://github.com/mybb/mybb2/blob/master/app/Providers/RouteServiceProvider.php#L35
However the search id is a string so the route couldn't be found. I've simply renamed it to `token` in that route and fixed one more issue with the view.

@euantorano Probably we should rename the whole column everywhere to `token` to avoid any confusion.