### PR TITLE
Fix routing for creating a new topic

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -29,12 +29,12 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        parent::boot();
-
         /** @var \Illuminate\Routing\Router $router */
         $router = $this->app['router'];
 
         $router->pattern('id', '\d+');
+
+        parent::boot();
     }
 
     /**


### PR DESCRIPTION
The route constraint must be defined before calling the parent boot method.