### PR TITLE
Fix RenderableInterface:getValidationRules sig

### DIFF
--- a/app/Form/RenderableInterface.php
+++ b/app/Form/RenderableInterface.php
@@ -43,5 +43,5 @@ interface RenderableInterface
     /**
      * @return string
      */
-    public function getValidationRules() : string;
+    public function getValidationRules() : array;
 }


### PR DESCRIPTION
Fixes #294 - validation rules are an array, not a string.